### PR TITLE
Added missing quotes for outlet/partial/view, convert single to double quotes

### DIFF
--- a/handlebars_linkto.sublime-snippet
+++ b/handlebars_linkto.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-{{link-to '${1:text}' '${2:route}' ${4:class='${5:class}'}}}
+{{link-to "${1:text}" "${2:route}"}}}
 ]]></content>
   <description>{{link-to }}</description>
   <tabTrigger>linkto</tabTrigger>

--- a/handlebars_linkto_block.sublime-snippet
+++ b/handlebars_linkto_block.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-{{#link-to '${1:route}'}}${2:text}{{/link-to}}
+{{#link-to "${1:route}"}}${2:text}{{/link-to}}
 ]]></content>
   <description>{{#link-to}} {{/link-to}}</description>
   <tabTrigger>linktoblock</tabTrigger>

--- a/handlebars_outlet.sublime-snippet
+++ b/handlebars_outlet.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-{{outlet ${1}}}
+{{outlet "${1}"}}
 ]]></content>
   <description>{{outlet }}</description>
   <tabTrigger>outlet</tabTrigger>

--- a/handlebars_partial.sublime-snippet
+++ b/handlebars_partial.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-{{partial ${1}}}
+{{partial "${1}"}}
 ]]></content>
   <description>{{partial }}</description>
   <tabTrigger>partial</tabTrigger>

--- a/handlebars_view.sublime-snippet
+++ b/handlebars_view.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
   <content><![CDATA[
-{{#view ${1:viewClass}}}
+{{#view "${1:viewClass}"}}
   ${2}
 {{/view}}
 ]]></content>


### PR DESCRIPTION
Non-quoted outlet/partial/view (and any others) are assumed to be property bindings. Also converted single quotes to double in link-to because the {{action}} helper uses double quotes and most devs I've seen use double as well, to match their HTML as well as the official ember.js guides.
